### PR TITLE
[Change] Adds Laravel 5.5 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,28 @@
 language: php
 
-php:
-  - 7.0
-  - 7.1
+matrix:
+  include:
+    - php: 7.0
+      env: ILLUMINATE_VERSION=5.4.*
+    - php: 7.0
+      env: ILLUMINATE_VERSION=5.5.*
+    - php: 7.1
+      env: ILLUMINATE_VERSION=5.4.*
+    - php: 7.1
+      env: ILLUMINATE_VERSION=5.5.*
+    - php: 7.2
+      env: ILLUMINATE_VERSION=5.4.*
+    - php: 7.2
+      env: ILLUMINATE_VERSION=5.5.*
 
-before_script: composer install
+before_install:
+  - composer require "illuminate/cache:${ILLUMINATE_VERSION}" --no-update
+  - composer require "illuminate/config:${ILLUMINATE_VERSION}" --no-update
+  - composer require "illuminate/console:${ILLUMINATE_VERSION}" --no-update
+  - composer require "illuminate/database:${ILLUMINATE_VERSION}" --no-update
+  - composer require "illuminate/support:${ILLUMINATE_VERSION}" --no-update
+
+before_script: composer update --prefer-source --no-interaction --dev
 
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,17 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.0",
-        "illuminate/cache": "^5.3",
-        "illuminate/config": "^5.3",
-        "illuminate/console": "^5.3",
-        "illuminate/database": "^5.3",
-        "illuminate/support": "^5.3",
+        "illuminate/cache": "^5.4",
+        "illuminate/config": "^5.4",
+        "illuminate/console": "^5.4",
+        "illuminate/database": "^5.4",
+        "illuminate/support": "^5.4",
         "opensoft/rollout": "^2.2"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "^0.4.4",
         "friendsofphp/php-cs-fixer": "^2.1",
-        "illuminate/container": "^5.3|^5.4",
+        "illuminate/container": "^5.4",
         "mockery/mockery": "^0.9.9",
         "orchestra/testbench": "^3.4",
         "phpunit/phpunit": "^6.0",

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -36,11 +36,9 @@ class ServiceProvider extends IlluminateServiceProvider
             $config = $app->make(Config::class);
 
             if ($config->get('laravel-rollout.storage') === 'database') {
-                $connection = $app->make(ConnectionInterface::class);
-                $encrypter = $app->make(Encrypter::class);
                 $table = $config->get('laravel-rollout.table');
 
-                $repository = new Repository(new DatabaseStore($connection, $encrypter, $table));
+                $repository = new Repository($app->make(DatabaseStore::class, ['table' => $table]));
                 $driver = new Cache($repository);
             } else {
                 $driver = new Cache($app->make('cache.store'));

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -38,7 +38,7 @@ class ServiceProvider extends IlluminateServiceProvider
             if ($config->get('laravel-rollout.storage') === 'database') {
                 $table = $config->get('laravel-rollout.table');
 
-                $repository = new Repository($app->make(DatabaseStore::class, ['table' => $table]));
+                $repository = new Repository($app->makeWith(DatabaseStore::class, ['table' => $table]));
                 $driver = new Cache($repository);
             } else {
                 $driver = new Cache($app->make('cache.store'));


### PR DESCRIPTION
This drops support for Laravel 5.3 since the tests on master fail against it now. 

I've also updated to ensure our test suite runs against multiple illuminate versions and works with versions of illuminate 5.4 and up.