### PR TITLE
Add support for Laravel package discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,12 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Jaspaul\\LaravelRollout\\ServiceProvider"
+            ]
+        }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,9 @@ composer require jaspaul/laravel-rollout
 
 ### Configuring the Service Provider
 
-Open config/app.php and register the required service provider above your application providers.
+On Laravel 5.5, the package discovery will configure the service provider automatically.
+
+On Laravel 5.4, open config/app.php and register the required service provider above your application providers.
 
 ```php
 'providers' => [


### PR DESCRIPTION
This should make it easier to install on Laravel 5.5