### PR TITLE
[Feature] Introduces the ability to define groups for rollout

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,8 @@ ROLLOUT_TABLE=rollout
 
 ### Implementing Interfaces
 
-Your rollout users must implement the `\Jaspaul\LaravelRollout\Helpers\User` interface. Often this will be your main user object:
+##### User
+Your rollout users must implement the `\Jaspaul\LaravelRollout\Contracts\User` interface. Often this will be your main user object:
 
 ```php
 <?php
@@ -76,7 +77,62 @@ class User implements Contract
 }
 ```
 
+#### Group
+Your rollout groups must implement the `\Jaspaul\LaravelRollout\Contracts\Group` interface.
+
+```php
+<?php
+
+use Jaspaul\LaravelRollout\Contracts\Group;
+
+class BetaUsersGroup implements Group
+{
+    /**
+     * The name of the group.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'beta-users';
+    }
+
+     /**
+     * Defines the rule membership in the group.
+     *
+     * @return boolean
+     */
+    public function hasMember($user = null): bool
+    {
+        if (!is_null($user)) {
+            return $user->hasOptedIntoBeta();
+        }
+
+        return false;
+    }
+}
+```
+
+and you should update your local `laravel-rollout.php` configuration to include the group in the groups array:
+
+`laravel-rollout.php`
+```php
+return [
+    ...
+    'groups' => [
+        BetaUsersGroup::class
+    ],
+    ...
+]
+```
+
 ## Commands
+
+### Add Group
+
+`php artisan rollout:add-group {feature} {group}`
+
+Swap `{feature}` with the name of the feature, and `{group}` with the name you defined in the group class.
 
 ### Add User
 
@@ -119,6 +175,12 @@ Swap `{feature}` with the name of the feature you'd like to rollout to 100% of y
 `php artisan rollout:percentage {feature} {percentage}`
 
 Swap `{feature}` with the name of the feature you'd like to rollout, and `{percentage}` with the percentage of users to rollout the feature to.
+
+### Remove Group
+
+`php artisan rollout:remove-group {feature} {group}`
+
+Swap `{feature}` with the name of the feature, and `{group}` with the name you defined in the group class.
 
 ### Remove User
 

--- a/resources/config/laravel-rollout.php
+++ b/resources/config/laravel-rollout.php
@@ -2,5 +2,6 @@
 
 return [
     'storage' => env('ROLLOUT_STORAGE', 'cache'),
-    'table' => env('ROLLOUT_TABLE', 'rollout')
+    'table' => env('ROLLOUT_TABLE', 'rollout'),
+    'groups' => [],
 ];

--- a/src/Console/AddGroupCommand.php
+++ b/src/Console/AddGroupCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jaspaul\LaravelRollout\Console;
+
+class AddGroupCommand extends RolloutCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rollout:add-group {feature} {group}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Enables the provided feature for the group.';
+
+    /**
+     * Adds the provided group to the requested feature. Note this will create
+     * the feature as a side effect.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $name = $this->argument('feature');
+        $group = $this->argument('group');
+
+        $this->rollout->activateGroup($name, $group);
+
+        $this->renderFeatureAsTable($name);
+    }
+}

--- a/src/Console/RemoveGroupCommand.php
+++ b/src/Console/RemoveGroupCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Jaspaul\LaravelRollout\Console;
+
+use Jaspaul\LaravelRollout\Helpers\User;
+
+class RemoveGroupCommand extends RolloutCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rollout:remove-group {feature} {group}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Removes the provided group from the feature.';
+
+    /**
+     * Removes the provided user from the feature. Note this will create
+     * the feature as a side effect.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $name = $this->argument('feature');
+        $group = $this->argument('group');
+
+        $this->rollout->deactivateGroup($name, $group);
+
+        $this->renderFeatureAsTable($name);
+    }
+}

--- a/src/Contracts/Group.php
+++ b/src/Contracts/Group.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Jaspaul\LaravelRollout\Contracts;
+
+use Opensoft\Rollout\RolloutUserInterface;
+
+interface Group
+{
+    /**
+     * The name of the group.
+     *
+     * @return string
+     */
+    public function getName(): string;
+
+    /**
+     * Checks if the given user is a member of this group.
+     *
+     * @param mixed $user
+     *
+     * @return boolean
+     */
+    public function hasMember($user = null): bool;
+}

--- a/src/FeaturePresenter.php
+++ b/src/FeaturePresenter.php
@@ -109,6 +109,16 @@ class FeaturePresenter
     }
 
     /**
+     * Returns a list of the groups that have this feature enabled.
+     *
+     * @return string
+     */
+    public function getGroups() : string
+    {
+        return implode(', ', $this->feature->getGroups());
+    }
+
+    /**
      * Returns an array representation of the feature presenter.
      *
      * @return array
@@ -120,7 +130,8 @@ class FeaturePresenter
             'status' => $this->getDisplayStatus(),
             'request-parameter' => $this->getRequestParameter(),
             'percentage' => $this->getPercentage(),
-            'users' => $this->getUsers()
+            'users' => $this->getUsers(),
+            'groups' => $this->getGroups(),
         ];
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -12,11 +12,13 @@ use Jaspaul\LaravelRollout\Console\ListCommand;
 use Jaspaul\LaravelRollout\Console\CreateCommand;
 use Jaspaul\LaravelRollout\Console\DeleteCommand;
 use Jaspaul\LaravelRollout\Console\AddUserCommand;
+use Jaspaul\LaravelRollout\Console\AddGroupCommand;
 use Jaspaul\LaravelRollout\Console\EveryoneCommand;
 use Illuminate\Contracts\Config\Repository as Config;
 use Jaspaul\LaravelRollout\Console\DeactivateCommand;
 use Jaspaul\LaravelRollout\Console\PercentageCommand;
 use Jaspaul\LaravelRollout\Console\RemoveUserCommand;
+use Jaspaul\LaravelRollout\Console\RemoveGroupCommand;
 use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
 
 class ServiceProvider extends IlluminateServiceProvider
@@ -44,10 +46,13 @@ class ServiceProvider extends IlluminateServiceProvider
                 $driver = new Cache($app->make('cache.store'));
             }
 
-            return new Rollout($driver);
+            $this->loadGroups($rollout = new Rollout($driver), $config->get('laravel-rollout.groups'));
+
+            return $rollout;
         });
 
         $this->commands([
+            AddGroupCommand::class,
             AddUserCommand::class,
             CreateCommand::class,
             DeactivateCommand::class,
@@ -55,6 +60,7 @@ class ServiceProvider extends IlluminateServiceProvider
             EveryoneCommand::class,
             ListCommand::class,
             PercentageCommand::class,
+            RemoveGroupCommand::class,
             RemoveUserCommand::class
         ]);
     }
@@ -67,7 +73,8 @@ class ServiceProvider extends IlluminateServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(
-            __DIR__.'/../resources/config/laravel-rollout.php', 'laravel-rollout'
+            __DIR__.'/../resources/config/laravel-rollout.php',
+            'laravel-rollout'
         );
     }
 
@@ -91,5 +98,20 @@ class ServiceProvider extends IlluminateServiceProvider
     protected function loadMigrations()
     {
         $this->loadMigrationsFrom(__DIR__.'/../resources/migrations');
+    }
+
+    /**
+     * Loads our groups
+     *
+     * @return void
+     */
+    protected function loadGroups(Rollout $rollout, array $groups)
+    {
+        foreach ($groups as $group) {
+            $instance = new $group();
+            $rollout->defineGroup($instance->getName(), function ($user = null) use ($instance) {
+                return $instance->hasMember($user);
+            });
+        }
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -108,7 +108,7 @@ class ServiceProvider extends IlluminateServiceProvider
     protected function loadGroups(Rollout $rollout, array $groups)
     {
         foreach ($groups as $group) {
-            $instance = new $group();
+            $instance = resolve($group);
             $rollout->defineGroup($instance->getName(), function ($user = null) use ($instance) {
                 return $instance->hasMember($user);
             });

--- a/tests/Console/AddGroupCommandTest.php
+++ b/tests/Console/AddGroupCommandTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Artisan;
 use Jaspaul\LaravelRollout\Helpers\User;
 use Jaspaul\LaravelRollout\Drivers\Cache;
 
-class AddGropuCommandTest extends TestCase
+class AddGroupCommandTest extends TestCase
 {
     /**
      * @test

--- a/tests/Console/AddGroupCommandTest.php
+++ b/tests/Console/AddGroupCommandTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Drivers;
+
+use Tests\TestCase;
+use Opensoft\Rollout\Rollout;
+use Tests\Doubles\SampleGroup;
+use Illuminate\Support\Facades\Artisan;
+use Jaspaul\LaravelRollout\Helpers\User;
+use Jaspaul\LaravelRollout\Drivers\Cache;
+
+class AddGropuCommandTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function running_the_command_with_a_feature_will_create_the_corresponding_feature()
+    {
+        Artisan::call('rollout:add-group', [
+            'feature' => 'derp',
+            'group' => 'ballers'
+        ]);
+
+        $store = app()->make('cache.store')->getStore();
+
+        $this->assertEquals('derp', $store->get('rollout.feature:__features__'));
+        $this->assertEquals('0||ballers|', $store->get('rollout.feature:derp'));
+    }
+
+    /**
+     * @test
+     */
+    public function rollout_will_flag_a_user_as_active_if_the_group_returns_true()
+    {
+        config(['laravel-rollout.groups' => [SampleGroup::class]]);
+
+        $this->assertFalse(app()->make(Rollout::class)->isActive('derp', new User('id')));
+
+        Artisan::call('rollout:add-group', [
+            'feature' => 'derp',
+            'group' => 'sample-group'
+        ]);
+
+        $this->assertTrue(app()->make(Rollout::class)->isActive('derp', new User('id')));
+    }
+}

--- a/tests/Console/RemoveGroupCommandTest.php
+++ b/tests/Console/RemoveGroupCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Drivers;
+
+use Tests\TestCase;
+use Opensoft\Rollout\Rollout;
+use Illuminate\Support\Facades\Artisan;
+use Jaspaul\LaravelRollout\Helpers\User;
+use Jaspaul\LaravelRollout\Drivers\Cache;
+
+class RemoveGroupCommandTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function running_the_command_with_a_feature_will_remove_the_corresponding_user()
+    {
+        $store = app()->make('cache.store')->getStore();
+
+        $rollout = app()->make(Rollout::class);
+        $rollout->activateGroup('derp', 'ballers');
+
+        $this->assertEquals('derp', $store->get('rollout.feature:__features__'));
+        $this->assertEquals('0||ballers|', $store->get('rollout.feature:derp'));
+
+        Artisan::call('rollout:remove-group', [
+            'feature' => 'derp',
+            'group' => 'ballers'
+        ]);
+
+        $this->assertEquals('derp', $store->get('rollout.feature:__features__'));
+        $this->assertEquals('0|||', $store->get('rollout.feature:derp'));
+    }
+}

--- a/tests/Doubles/SampleGroup.php
+++ b/tests/Doubles/SampleGroup.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Doubles;
+
+use Tests\TestCase;
+use Jaspaul\LaravelRollout\Contracts\Group;
+
+class SampleGroup implements Group
+{
+    /**
+     * The name of the group.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'sample-group';
+    }
+
+    /**
+     * Defines the rule membership in the group.
+     *
+     * @param mixed $user
+     *
+     * @return boolean
+     */
+    public function hasMember($user = null): bool
+    {
+        return true;
+    }
+}

--- a/tests/FeaturePresenterTest.php
+++ b/tests/FeaturePresenterTest.php
@@ -10,7 +10,7 @@ class FeaturePresenterTest extends TestCase
     /**
      * @test
      */
-    function get_name_returns_the_name_of_the_feature()
+    public function get_name_returns_the_name_of_the_feature()
     {
         $feature = new Feature('name');
         $presenter = new FeaturePresenter($feature);
@@ -21,7 +21,7 @@ class FeaturePresenterTest extends TestCase
     /**
      * @test
      */
-    function get_display_status_returns_the_all_message_if_the_feature_is_100_percent_enabled()
+    public function get_display_status_returns_the_all_message_if_the_feature_is_100_percent_enabled()
     {
         $feature = new Feature('name');
         $feature->setPercentage(100);
@@ -34,7 +34,7 @@ class FeaturePresenterTest extends TestCase
     /**
      * @test
      */
-    function get_display_status_returns_the_request_parameter_message_if_only_a_request_parameter_is_set()
+    public function get_display_status_returns_the_request_parameter_message_if_only_a_request_parameter_is_set()
     {
         $feature = new Feature('name');
         $feature->setRequestParam('derp');
@@ -47,7 +47,7 @@ class FeaturePresenterTest extends TestCase
     /**
      * @test
      */
-    function get_display_status_returns_the_percentage_message_if_it_is_enabled_for_more_than_0_but_less_than_100_percent_of_users()
+    public function get_display_status_returns_the_percentage_message_if_it_is_enabled_for_more_than_0_but_less_than_100_percent_of_users()
     {
         $feature = new Feature('name');
         $feature->setPercentage(80);
@@ -60,7 +60,7 @@ class FeaturePresenterTest extends TestCase
     /**
      * @test
      */
-    function get_display_status_returns_the_whitelist_message_if_it_is_enabled_for_groups()
+    public function get_display_status_returns_the_whitelist_message_if_it_is_enabled_for_groups()
     {
         $feature = new Feature('name', '0||d');
         $presenter = new FeaturePresenter($feature);
@@ -71,7 +71,7 @@ class FeaturePresenterTest extends TestCase
     /**
      * @test
      */
-    function get_display_status_returns_the_whitelist_message_if_it_is_enabled_for_users()
+    public function get_display_status_returns_the_whitelist_message_if_it_is_enabled_for_users()
     {
         $feature = new Feature('name', '0|a|');
         $presenter = new FeaturePresenter($feature);
@@ -82,7 +82,7 @@ class FeaturePresenterTest extends TestCase
     /**
      * @test
      */
-    function get_display_status_returns_the_whitelist_message_if_it_is_enabled_for_users_and_groups()
+    public function get_display_status_returns_the_whitelist_message_if_it_is_enabled_for_users_and_groups()
     {
         $feature = new Feature('name', '0|a|d');
         $presenter = new FeaturePresenter($feature);
@@ -93,7 +93,7 @@ class FeaturePresenterTest extends TestCase
     /**
      * @test
      */
-    function get_request_parameter_returns_an_emtpy_string_if_a_request_parameter_is_not_set_on_the_feature()
+    public function get_request_parameter_returns_an_emtpy_string_if_a_request_parameter_is_not_set_on_the_feature()
     {
         $feature = new Feature('name');
         $presenter = new FeaturePresenter($feature);
@@ -104,7 +104,7 @@ class FeaturePresenterTest extends TestCase
     /**
      * @test
      */
-    function get_request_parameter_returns_the_request_parameter_when_one_is_set()
+    public function get_request_parameter_returns_the_request_parameter_when_one_is_set()
     {
         $feature = new Feature('name', '0|a|d|param');
         $presenter = new FeaturePresenter($feature);
@@ -115,7 +115,7 @@ class FeaturePresenterTest extends TestCase
     /**
      * @test
      */
-    function get_percentage_returns_the_percentage_of_users_the_feature_is_enabled_for()
+    public function get_percentage_returns_the_percentage_of_users_the_feature_is_enabled_for()
     {
         $feature = new Feature('name');
         $presenter = new FeaturePresenter($feature);
@@ -131,7 +131,7 @@ class FeaturePresenterTest extends TestCase
     /**
      * @test
      */
-    function get_users_returns_an_empty_string_by_default()
+    public function get_users_returns_an_empty_string_by_default()
     {
         $feature = new Feature('name');
         $presenter = new FeaturePresenter($feature);
@@ -142,7 +142,7 @@ class FeaturePresenterTest extends TestCase
     /**
      * @test
      */
-    function get_users_returns_a_comma_seperated_string_of_users()
+    public function get_users_returns_a_comma_seperated_string_of_users()
     {
         $feature = new Feature('name', '0|user_1,user_2,user_3||param');
         $presenter = new FeaturePresenter($feature);
@@ -153,14 +153,15 @@ class FeaturePresenterTest extends TestCase
     /**
      * @test
      */
-    function to_array_returns_an_array_representation_of_the_underlying_feature()
+    public function to_array_returns_an_array_representation_of_the_underlying_feature()
     {
         $expected = [
             'name' => 'name',
             'status' => FeaturePresenter::$statuses['request_param'],
             'request-parameter' => 'param',
             'percentage' => 0,
-            'users' => 'a'
+            'users' => 'a',
+            'groups' => 'd',
         ];
 
         $feature = new Feature('name', '0|a|d|param');

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -13,12 +13,15 @@ use Jaspaul\LaravelRollout\Console\ListCommand;
 use Jaspaul\LaravelRollout\Console\CreateCommand;
 use Jaspaul\LaravelRollout\Console\DeleteCommand;
 use Jaspaul\LaravelRollout\Console\AddUserCommand;
+use Jaspaul\LaravelRollout\Console\AddGroupCommand;
 use Jaspaul\LaravelRollout\Console\EveryoneCommand;
 use Illuminate\Contracts\Config\Repository as Config;
 use Jaspaul\LaravelRollout\Console\DeactivateCommand;
 use Jaspaul\LaravelRollout\Console\PercentageCommand;
 use Jaspaul\LaravelRollout\Console\RemoveUserCommand;
+use Jaspaul\LaravelRollout\Console\RemoveGroupCommand;
 use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
+use Tests\Doubles\SampleGroup;
 
 class ServiceProviderTest extends TestCase
 {
@@ -28,7 +31,7 @@ class ServiceProviderTest extends TestCase
     /**
      * @before
      */
-    function setup_service_provider()
+    public function setup_service_provider()
     {
         $this->container = Container::getInstance();
         $this->serviceProvider = new ServiceProvider($this->container);
@@ -37,7 +40,7 @@ class ServiceProviderTest extends TestCase
     /**
      * @test
      */
-    function ensure_a_service_provider_can_be_constructed()
+    public function ensure_a_service_provider_can_be_constructed()
     {
         $this->assertInstanceOf(ServiceProvider::class, $this->serviceProvider);
         $this->assertInstanceOf(IlluminateServiceProvider::class, $this->serviceProvider);
@@ -46,13 +49,16 @@ class ServiceProviderTest extends TestCase
     /**
      * @test
      */
-    function booting_registers_a_cache_backed_rollout_singleton_into_the_container()
+    public function booting_registers_a_cache_backed_rollout_singleton_into_the_container()
     {
         $this->container->singleton(Config::class, function ($app) {
             $config = Mockery::mock(Config::class);
             $config->shouldReceive('get')
                 ->with('laravel-rollout.storage')
                 ->andReturn('cache');
+            $config->shouldReceive('get')
+                ->with('laravel-rollout.groups')
+                ->andReturn([]);
 
             return $config;
         });
@@ -70,7 +76,7 @@ class ServiceProviderTest extends TestCase
     /**
      * @test
      */
-    function booting_registers_a_database_backed_rollout_singleton_into_the_container()
+    public function booting_registers_a_database_backed_rollout_singleton_into_the_container()
     {
         $this->container->singleton(Config::class, function ($app) {
             $config = Mockery::mock(Config::class);
@@ -81,6 +87,10 @@ class ServiceProviderTest extends TestCase
             $config->shouldReceive('get')
                 ->with('laravel-rollout.table')
                 ->andReturn('rollout');
+
+            $config->shouldReceive('get')
+                ->with('laravel-rollout.groups')
+                ->andReturn([]);
 
             return $config;
         });
@@ -102,13 +112,52 @@ class ServiceProviderTest extends TestCase
     /**
      * @test
      */
-    function booting_registers_our_commands()
+    public function booting_registers_the_groups_into_rollout()
+    {
+        $this->container->singleton(Config::class, function ($app) {
+            $config = Mockery::mock(Config::class);
+            $config->shouldReceive('get')
+                ->with('laravel-rollout.storage')
+                ->andReturn('database');
+
+            $config->shouldReceive('get')
+                ->with('laravel-rollout.table')
+                ->andReturn('rollout');
+
+            $config->shouldReceive('get')
+                ->with('laravel-rollout.groups')
+                ->andReturn([
+                    SampleGroup::class
+                ]);
+
+            return $config;
+        });
+
+        $this->container->singleton(ConnectionInterface::class, function ($app) {
+            return Mockery::mock(ConnectionInterface::class);
+        });
+
+        $this->container->singleton(Encrypter::class, function ($app) {
+            return Mockery::mock(Encrypter::class);
+        });
+
+        $this->serviceProvider->boot();
+
+        $result = $this->container->make(Rollout::class);
+        $this->assertInstanceOf(Rollout::class, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function booting_registers_our_commands()
     {
         $serviceProvider = new TestServiceProvider($this->container);
         $serviceProvider->boot();
 
         $this->assertEquals(
             [
+                AddGroupCommand::class,
                 AddUserCommand::class,
                 CreateCommand::class,
                 DeactivateCommand::class,
@@ -116,6 +165,7 @@ class ServiceProviderTest extends TestCase
                 EveryoneCommand::class,
                 ListCommand::class,
                 PercentageCommand::class,
+                RemoveGroupCommand::class,
                 RemoveUserCommand::class
             ],
             $serviceProvider->commands


### PR DESCRIPTION
With this change you should be able to define new groups and leverage them through rollout. For instance you can rollout `cool-feature` to `beta-users` with `php artisan rollout:add-group cool-feature beta-users`, assuming the following is configured in your system.

`config/laravel-rollout.php`
```php
return [
    'storage' => env('ROLLOUT_STORAGE', 'cache'),
    'table' => env('ROLLOUT_TABLE', 'rollout')
    'groups' => [
        Jaspaul\CoolProject\Groups\BetaUsersGroup::class
    ],
];
```

`src\CoolProjects\Groups.php`
```php
namespace Jaspaul\CoolProject\Groups;

use Jaspaul\LaravelRollout\Contracts\Group;

class BetaUsersGroup implements Group
{
    /**
     * The name of the group.
     *
     * @return string
     */
    public function getName(): string
    {
        return 'beta-users';
    }

     /**
     * Defines the rule membership in the group.
     *
     * @return boolean
     */
    public function hasMember($user = null): bool
    {
        if (!is_null($user)) {
            return $user->hasOptedIntoBeta();
        }

        return false;
    }
}
```

