### PR TITLE
[Bugfix] Rollback Rollout Version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/console": "^5.4",
         "illuminate/database": "^5.4",
         "illuminate/support": "^5.4",
-        "opensoft/rollout": "^2.2"
+        "opensoft/rollout": "2.2.*"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "^0.4.4",


### PR DESCRIPTION
This prevents laravel-rollout from updating to version 2.3 of opensoft/rollout until we can support the new functionality fully.