### PR TITLE
Update dependencies for Laravel 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.2.5",
-        "illuminate/cache": "^7",
-        "illuminate/config": "^7",
-        "illuminate/console": "^7",
-        "illuminate/database": "^7",
-        "illuminate/support": "^7",
+        "illuminate/cache": "^7|^8",
+        "illuminate/config": "^7|^8",
+        "illuminate/console": "^7|^8",
+        "illuminate/database": "^7|^8",
+        "illuminate/support": "^7|^8",
         "opensoft/rollout": "2.2.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.1",
-        "illuminate/container": "^7",
+        "illuminate/container": "^7|^8",
         "mockery/mockery": "^1.2",
         "orchestra/testbench": "^5.0",
         "php-coveralls/php-coveralls": "^2.1",


### PR DESCRIPTION
The package wasn't installable on Laravel 8. I updated all Illuminate dependencies to support Laravel 8.